### PR TITLE
Fix errors that are blank but shouldn't be

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='txccb',
-    version='0.1.3',
+    version='0.1.4',
     description='Twisted CCB Integration',
     long_description=readme + '\n\n' + history,
     author='Trenton Broughton',

--- a/txccb/client.py
+++ b/txccb/client.py
@@ -40,7 +40,10 @@ class CCBClient(object):
             raise errors.CCBError('Internal Error')
         response = content.find('response')
         if not response:
-            raise errors.CCBError("No response received")
+            error = content.find("error")
+            if error is not None:
+                raise errors.CCBError(error.text, error.get("number"))
+            raise errors.CCBError("No response received", "-1")
         if response.find('errors'):
             error = response.find('errors')[0]
             raise errors.CCBError(error.text, error.get('number'))


### PR DESCRIPTION
- Some CCB errors are not in a response object, and have a different schema
